### PR TITLE
Changes required to start migrating issues to Jira

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
       Whether the action is run as a cron job.
       Set true to trigger syncing of new PRs.
     required: false
+  sync_label:
+    description: >
+      Require a specific label to be present to enable syncing to Jira.
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,13 @@ inputs:
     description: >
       Require a specific label to be present to enable syncing to Jira.
     required: false
+  find_jira_retries:
+    description: >
+      The number of times the action will try to find the issue in Jira
+      before deciding to create a new issue. This is used to avoid race conditions
+      between action executions.
+    required: false
+    default: '5'
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,11 @@ inputs:
       Whether the action is run as a cron job.
       Set true to trigger syncing of new PRs.
     required: false
+  status_field_id:
+    description: >
+      The custom field id of the GitHub Issue status field in Jira.
+    required: false
+    default: '12100'
   sync_label:
     description: >
       Require a specific label to be present to enable syncing to Jira.

--- a/sync_jira_actions/sync_issue.py
+++ b/sync_jira_actions/sync_issue.py
@@ -34,7 +34,7 @@ GITHUB = Github(os.environ['GITHUB_TOKEN'])
 # Initialize GitHub repository
 REPO = GITHUB.get_repo(os.environ['GITHUB_REPOSITORY'])
 # Set the number of retries before deciding Jira issue does not exist.
-FIND_JIRA_RETRIES = os.environ.get('INPUT_FIND_JIRA_RETRIES', 5)
+FIND_JIRA_RETRIES = int(os.environ.get('INPUT_FIND_JIRA_RETRIES', 5))
 
 def handle_issue_opened(jira, event):
     gh_issue = event['issue']

--- a/sync_jira_actions/sync_issue.py
+++ b/sync_jira_actions/sync_issue.py
@@ -33,7 +33,8 @@ JIRA_BUG_TYPE_ID = 10004
 GITHUB = Github(os.environ['GITHUB_TOKEN'])
 # Initialize GitHub repository
 REPO = GITHUB.get_repo(os.environ['GITHUB_REPOSITORY'])
-
+# Set the number of retries before deciding Jira issue does not exist.
+FIND_JIRA_RETRIES = os.environ.get('INPUT_FIND_JIRA_RETRIES', 5)
 
 def handle_issue_opened(jira, event):
     gh_issue = event['issue']
@@ -448,7 +449,7 @@ def _get_jira_issue_type(jira, gh_issue):
     return None  # updating a field to None seems to cause 'no change' for JIRA
 
 
-def _find_jira_issue(jira, gh_issue, gh_repo, make_new=False, retries=5):
+def _find_jira_issue(jira, gh_issue, gh_repo, make_new=False, retries=FIND_JIRA_RETRIES):
     """Look for a JIRA issue which has a remote link to the provided GitHub issue.
 
     Will also find "manually synced" issues that point to each other by name

--- a/sync_jira_actions/sync_issue.py
+++ b/sync_jira_actions/sync_issue.py
@@ -323,8 +323,21 @@ def _create_jira_issue(jira, gh_issue, gh_repo):
     if gh_issue['state'] != 'open':
         # mark the link to GitHub as resolved
         _update_link_resolved(jira, gh_issue, issue)
-
+    _add_existing_comments(jira, gh_issue, issue.id)
     return issue
+
+
+def _add_existing_comments(jira, gh_issue, issue_id):
+    """
+    Add all existing comments to a jira issue
+    """
+    comment_count = int(gh_issue.get('comments', 0))
+    if comment_count > 0:
+        print(f"Adding {comment_count} existing comment/s to Jira issue")
+        comments = REPO.get_issue(gh_issue['number']).get_comments().reversed
+        for comment in comments:
+            gh_comment = dict(body=comment.body, html_url=comment.html_url, user={"login":  comment.user.login})
+            jira.add_comment(issue_id, _get_jira_comment_body(gh_comment))
 
 
 def _add_remote_link(jira, issue, gh_issue):


### PR DESCRIPTION
- Added an optional sync_label input to allow syncing of issues only with a specific label.
- Added status_field_id input to allow configurable github status field in Jira
- Only try to use issues types for the specified Jira project. This fixes a bug when creating issues.
- Add all previous comments when creating Jira issue
- Added an input to configure the number of retries before deciding the issue does not yet exist in Jira