### PR TITLE
feat: Added link_closing_issues feature and handle pull_request_target event

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,11 @@ inputs:
       between action executions.
     required: false
     default: '5'
+  link_closing_issues:
+    description: >
+      Find issues that a PR will close then add the Jira issue number to the title
+      of the PR. When a closing issue is found syncing will be skipped for the PR.
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"


### PR DESCRIPTION
Closes DCNE-167

Added a new action option called `link_closing_issues`.
This will cause syncing on PRs to find any linked GitHub issues that will be closed by the PR.
Once found, the issues are checked for a synced Jira issue key. When Jira keys are found these are inserted into the title of the PR.
The goal is to automate the process of linking PRs to their directly related Jira issue while also reducing the possibility of duplicate Jira issues being created.

Additionally a change was also made so the sync action can handle the `pull_request_target` event. This will allow syncing of PRs in the context of the target repo instead of the source repo. This means the Jira secrets can be used and any updates to description/labels/title ect. will trigger syncing correctly. Previously only PR comments triggered the syncing.