### PR TITLE
Add fixes to support issue moved to a different project (DCNE-801)

### DIFF
--- a/sync_jira_actions/sync_issue.py
+++ b/sync_jira_actions/sync_issue.py
@@ -469,7 +469,7 @@ def _find_jira_issue(jira, gh_issue, gh_repo, make_new=False, retries=FIND_JIRA_
     # and they're not always processed in order.
     """
     url = gh_issue['html_url']
-    jql_query = f'issue in issuesWithRemoteLinksByGlobalId("{url}") order by updated desc'
+    jql_query = f'issue in issuesWithRemoteLinksByGlobalId("{url}") OR issue in workItemsWithRemoteLinksByGlobalId("{url}") order by updated desc'
     print(f'JQL query: {jql_query}')
     res = jira.enhanced_search_issues(jql_query)
     if not res:

--- a/sync_jira_actions/sync_pr.py
+++ b/sync_jira_actions/sync_pr.py
@@ -85,23 +85,23 @@ def find_and_link_pr_issues(gh_issue):
     This allows auto linking of PR's to related Jira issues.
     """
     token = os.environ['GITHUB_TOKEN']
-    project = os.environ['JIRA_PROJECT']
     github = Github(os.environ['GITHUB_TOKEN'])
     repo = github.get_repo(os.environ['GITHUB_REPOSITORY'])
     pr_number = int(gh_issue['number'])
     pr_title = gh_issue['title']
     closing_issues = find_closing_issues(token, repo.owner.login, repo.name, pr_number)
+    print(f"Closing Issues: {closing_issues}")
     jira_keys = []
     for issue in closing_issues:
         title = issue.get('title')
-        match = re.search(f'.*({project}-\d*).*', title)
+        match = re.search(r'.*\(([A-Z]{3,4}-\d+)\).*', title)
         if match:
             jira_key = match.group(1)
             print(f"Found linked issue: {jira_key}")
             jira_keys.append(jira_key)
     if len(jira_keys) > 0:
-        new_pr_title = re.sub(f'{project}-\d*', '', pr_title)
-        new_pr_title = re.sub('\(\s*\)', '', new_pr_title).strip()
+        new_pr_title = re.sub(r'[A-Z]{3,4}-\d+', '', pr_title)
+        new_pr_title = re.sub(r'\(\s*\)', '', new_pr_title).strip()
         new_pr_title = f'{new_pr_title} ({" ".join(jira_keys)})'
         print(f'New PR title: {new_pr_title}')
         repo.get_issue(pr_number).edit(title=new_pr_title)


### PR DESCRIPTION
1. Query for Jira items using `workItemsWithRemoteLinksByGlobalId`. This seams to be a new Jira query function. Use both to capture all items.
2. Fix the closing issue feature to find and link any Jira style project key. eg. DCNE and NDA. Must still be 3-4 uppercase characters.