### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -3,6 +3,9 @@ name: Tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ciscoecosystem/sync-jira-actions/security/code-scanning/1](https://github.com/ciscoecosystem/sync-jira-actions/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/python-test.yml` at the workflow root, directly under `on:` (or under `name:`/`on:` region), so it applies to all jobs unless overridden. For this test-only workflow, the minimal required permission is:

- `contents: read`

This preserves existing functionality (`actions/checkout` and test execution) while enforcing least privilege for `GITHUB_TOKEN`. No imports, methods, or external definitions are needed—just YAML configuration in the shown file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
